### PR TITLE
Add `M-x clay-stop`

### DIFF
--- a/clay.el
+++ b/clay.el
@@ -52,6 +52,13 @@ E.g., \"/ssh:myserver:/home/myuSER/myfile\" `-->' \"/home/myuser/myfile\""
     (scicloj.clay.v2.api/start!)")
   t)
 
+(defun clay-stop ()
+  "Stop Clay if running"
+  (interactive)
+  (cider-interactive-eval "
+    ((requiring-resolve 'scicloj.clay.v2.api/stop!))")
+  t)
+
 (defun clay-make-ns (format)
   "Save this Clojure buffer, and render it at the desired FORMAT."
   (save-buffer)


### PR DESCRIPTION
## Context

Useful in situation where Clay gets stuck, when there's been a failure to download resources, such as if Clay crashes (https://github.com/scicloj/clay/issues/268).

In the referred issue, I ran `M-x clay-stop` then `M-x clay-start` after connecting to Internet, and Clay was working properly afterwards.

## Discussion

I think this should be generally helpful to others too — at least I prefer to also be able to stop things that binds to ports. But do let me know if there's something I should consider!