### PR TITLE
provide 'clay is missing autoloads

### DIFF
--- a/clay.el
+++ b/clay.el
@@ -44,6 +44,7 @@ E.g., \"/ssh:myserver:/home/myuSER/myfile\" `-->' \"/home/myuser/myfile\""
     (require '[scicloj.clay.v2.api])")
   t)
 
+;;;###autoload
 (defun clay-start ()
   "Start Clay if not started yet."
   (interactive)
@@ -52,6 +53,7 @@ E.g., \"/ssh:myserver:/home/myuSER/myfile\" `-->' \"/home/myuser/myfile\""
     (scicloj.clay.v2.api/start!)")
   t)
 
+;;;###autoload
 (defun clay-make-ns (format)
   "Save this Clojure buffer, and render it at the desired FORMAT."
   (save-buffer)


### PR DESCRIPTION
The Clay library is provided, but no autoloads are defined. 

With autoloads defined on one or two entry functions, users don't need to add `(require 'clay)` to their init files. Those entry functions appear magically when you type M+x, provided the library has been installed in the load path. 

From the Emacs manual: 

> Emacs starts quicker with autoloaded functions, since their libraries are not loaded right away; but you need to wait a moment when you first use such a function, while its containing file is evaluated.

PS: I missed Hugo Duncan's PR addressing the exact same issue.